### PR TITLE
Change certain access status to hidden for not so good projects  #11

### DIFF
--- a/annif-projects/projects.cfg
+++ b/annif-projects/projects.cfg
@@ -4,6 +4,7 @@ language=de
 backend=tfidf
 analyzer=snowball(german)
 vocab=nwbib-de
+access=hidden 
 
 [nwbib-mllm]
 name=MLLM German NWBib
@@ -11,6 +12,7 @@ language=de
 backend=mllm
 analyzer=snowball(german)
 vocab=nwbib-de
+access=hidden 
 
 [nwbib-omikuji]
 name=Omikuji German NWBib
@@ -34,6 +36,7 @@ loss=hs
 limit=1000
 chunksize=24
 vocab=nwbib-de
+access=hidden 
 
 [nwbib-ensemble]
 name=Ensemble (TFIDF + Omikuji) NWBib
@@ -48,6 +51,7 @@ language=de
 backend=ensemble
 vocab=nwbib-de
 sources=nwbib-tfidf,nwbib-fasttext:2,nwbib-omikuji:2
+access=hidden 
 
 [nwbib-ensemble-nn]
 name=Ensemble (TFIDF + Omikuji) NWBib with neural network
@@ -59,6 +63,7 @@ nodes=200
 dropout_rate=0.2
 epochs=15
 lmdb_map_size=8589934592
+access=hidden 
 
 [nwbib-triple-ensemble-nn]
 name=Ensemble (TFIDF + fastText + Omikuji) NWBib with neural network


### PR DESCRIPTION
See #11 

Hide all projects besides omikuji and ensemlble nn (TFIDF + omikuji + fasttext) which perform well.

They are still available per API, but will not be presented in the Web UI.

This will help with the testing by the NWBib cataloguers.